### PR TITLE
Update links in photos.html

### DIFF
--- a/guest-speaker.html
+++ b/guest-speaker.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<meta http-equiv="Refresh" content="0; url='https://pacific.zoom.us/j/98459649193'" />

--- a/photos.html
+++ b/photos.html
@@ -80,7 +80,7 @@
       </div>
       
       <br>
-      <a class="link-button" href="https://drive.google.com/drive/folders/1sLzFHXllbKcD-vZjA9Pn4NPdhBTxOYpM?usp=sharing" target="_blank">
+      <a class="link-button" href="https://drive.google.com/drive/folders/1TU-5_tNsP80oEe_4XpThpEE0IEJTthGC?usp=sharing" target="_blank">
         <!-- <div style="float: left; width: 60px;">
           <img src="assets/icons/classroom.png" height=40px class="vertical-center">
         </div> -->
@@ -90,7 +90,7 @@
       </a>
 
       <br>
-      <a class="link-button" href="https://drive.google.com/drive/folders/1gbRn7MKHzerGhjuWyYlKknrnx9LKxiCp?usp=sharing" target="_blank">
+      <a class="link-button" href="https://drive.google.com/drive/folders/1V5x1C31QEgQTJDQ1PgMDqdNAbTOfBAdK?usp=sharing" target="_blank">
         <!-- <div style="float: left; width: 60px;">
           <img src="assets/icons/instagram.png" height=40px class="vertical-center">
         </div> -->
@@ -100,7 +100,7 @@
       </a>
 
       <br>
-      <a class="link-button" href="https://drive.google.com/drive/folders/1kR7eaXb3eiFpMUYSVPsnAsPED_jxGNsN?usp=sharing" target="_blank">
+      <a class="link-button" href="https://drive.google.com/drive/folders/1brj-qpKZtZe5ykFrhgvI_W4Z-Vjv235f?usp=sharing" target="_blank">
         <!-- <div style="float: left; width: 60px;">
           <img src="assets/icons/mesa.png" height=40px class="vertical-center">
         </div> -->


### PR DESCRIPTION
Photos were reuploaded using a different Google account for storage space reasons, so the folders have new links and these changes should be reflected in the website so users are not led to a Google Drive 404.